### PR TITLE
Remove the `T: Unpin` bound

### DIFF
--- a/src/body.rs
+++ b/src/body.rs
@@ -9,15 +9,10 @@ use crate::scope::Scope;
 /// It is not considered complete until (a) the body is done and (b) any spawned futures are done.
 /// Its result is whatever the body returned.
 ///
-/// # Notes
-///
-/// The `T: Unpin` requirement seems unfortunate but I am not smart enough at this moment
-/// to think about how to avoid it.
-///
 /// # Unsafe contract
 ///
 /// - `body_future` and `result` will be dropped BEFORE `scope`.
-pub(crate) struct Body<'scope, 'env: 'scope, T: 'env + Unpin, C: Send + 'env> {
+pub(crate) struct Body<'scope, 'env: 'scope, T: 'env, C: Send + 'env> {
     body_future: Option<BoxFuture<'scope, T>>,
     result: Option<T>,
     scope: Arc<Scope<'scope, 'env, C>>,
@@ -25,7 +20,6 @@ pub(crate) struct Body<'scope, 'env: 'scope, T: 'env + Unpin, C: Send + 'env> {
 
 impl<'scope, 'env, T, C> Body<'scope, 'env, T, C>
 where
-    T: Unpin,
     C: Send,
 {
     /// # Unsafe contract
@@ -48,7 +42,6 @@ where
 
 impl<'scope, 'env, T, C> Drop for Body<'scope, 'env, T, C>
 where
-    T: Unpin,
     C: Send,
 {
     fn drop(&mut self) {
@@ -60,7 +53,6 @@ where
 
 impl<'scope, 'env, T, C> Future for Body<'scope, 'env, T, C>
 where
-    T: Unpin,
     C: Send,
 {
     type Output = Result<T, C>;
@@ -89,3 +81,5 @@ where
         }
     }
 }
+
+impl<T, C: Send> Unpin for Body<'_, '_, T, C> {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@ pub fn scope_fn<'env, T, C>(
     body: impl for<'scope> FnOnce(&'scope Scope<'scope, 'env, C>) -> BoxFuture<'scope, T>,
 ) -> ScopeBody<'env, T, C>
 where
-    T: Unpin + 'env,
+    T: 'env,
     C: Send + 'env,
 {
     let scope = Scope::new();

--- a/src/scope_body.rs
+++ b/src/scope_body.rs
@@ -6,7 +6,6 @@ use crate::body::Body;
 
 pub struct ScopeBody<'env, T: 'env, C: 'env>
 where
-    T: Unpin,
     C: Send,
 {
     body: Body<'env, 'env, T, C>,
@@ -14,7 +13,6 @@ where
 
 impl<'env, T, C> ScopeBody<'env, T, C>
 where
-    T: Unpin,
     C: Send,
 {
     pub(crate) fn new(body: Body<'env, 'env, T, C>) -> Self {
@@ -22,7 +20,7 @@ where
     }
 }
 
-impl<'env, T: Unpin> ScopeBody<'env, T, Infallible> {
+impl<'env, T> ScopeBody<'env, T, Infallible> {
     pub async fn infallible(self) -> T {
         match self.body.await {
             Ok(v) => v,
@@ -33,7 +31,6 @@ impl<'env, T: Unpin> ScopeBody<'env, T, Infallible> {
 
 impl<'env, T, C> Future for ScopeBody<'env, T, C>
 where
-    T: Unpin,
     C: Send,
 {
     type Output = Result<T, C>;
@@ -45,3 +42,5 @@ where
         Pin::new(&mut self.get_mut().body).poll(cx)
     }
 }
+
+impl<T, C: Send> Unpin for ScopeBody<'_, T, C> {}


### PR DESCRIPTION
It can be avoided with manual `Unpin` implementations.