### PR TITLE
updates for Rust 1.85 / edition 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "moro"
 version = "0.4.0"
-edition = "2021"
+edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/nikomatsakis/moro"
 readme = "README.md"

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -1,5 +1,3 @@
-#![feature(async_closure)]
-
 #[tokio::main]
 pub async fn main() {
     let value = 22;

--- a/src/async_iter.rs
+++ b/src/async_iter.rs
@@ -17,7 +17,7 @@ pub trait AsyncIterator {
 
     fn filter(
         self,
-        op: impl async FnMut(&Self::Item) -> bool,
+        op: impl AsyncFnMut(&Self::Item) -> bool,
     ) -> impl AsyncIterator<Item = Self::Item>
     where
         Self: Sized,
@@ -53,7 +53,7 @@ impl<T: AsyncIterator> IntoAsyncIter for T {
 struct Filter<I, O>
 where
     I: AsyncIterator,
-    O: async FnMut(&I::Item) -> bool,
+    O: AsyncFnMut(&I::Item) -> bool,
 {
     iter: I,
     filter_op: O,
@@ -62,7 +62,7 @@ where
 impl<I, O> AsyncIterator for Filter<I, O>
 where
     I: AsyncIterator,
-    O: async FnMut(&I::Item) -> bool,
+    O: AsyncFnMut(&I::Item) -> bool,
 {
     type Item = I::Item;
 

--- a/src/body.rs
+++ b/src/body.rs
@@ -1,6 +1,5 @@
-use std::{pin::Pin, sync::Arc, task::Poll};
+use std::{future::Future, pin::Pin, sync::Arc, task::Poll};
 
-use futures::{Future, FutureExt};
 use pin_project::{pin_project, pinned_drop};
 
 use crate::scope::Scope;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(async_closure)]
 #![feature(async_fn_traits)]
 #![feature(unboxed_closures)]
 #![allow(async_fn_in_trait)]
@@ -174,7 +173,7 @@ pub fn scope<'env, R, B>(
 ) -> ScopeBody<'env, R, <B as AsyncFnOnce<(&'env scope::Scope<'env, 'env, R>,)>>::CallOnceFuture>
 where
     R: Send + 'env,
-    for<'scope> B: async FnOnce(&'scope Scope<'scope, 'env, R>) -> R,
+    for<'scope> B: AsyncFnOnce(&'scope Scope<'scope, 'env, R>) -> R,
 {
     let scope = Scope::new();
 


### PR DESCRIPTION
Fix errors and warnings on current nightlies, and bump `edition` to 2024.